### PR TITLE
Adding config to optionally have multipart prefix for temp files

### DIFF
--- a/pkg/aws/handler/s3/object/object_handler.go
+++ b/pkg/aws/handler/s3/object/object_handler.go
@@ -180,7 +180,7 @@ func (handler *Handler) CompleteMultiPartHandle(writer http.ResponseWriter, requ
 		bucket := handler.GCPClientToBucket(*s3Req.Bucket, client)
 		for _, part := range s3Req.MultipartUpload.Parts {
 			partNumber := *part.PartNumber
-			key := partFileName(*s3Req.Key, partNumber, handler.Config.GetString("gcp_destination_config.multipart_temp_file_prefix"))
+			key := partFileName(*s3Req.Key, partNumber, handler.Config.GetString("gcp_destination_config.gcs_config.multipart_temp_file_prefix"))
 			logging.Log.Info("Part number ", partNumber, " ", key)
 			objects = append(objects, bucket.Object(key))
 		}
@@ -313,7 +313,7 @@ func (handler *Handler) UploadPartHandle(writer http.ResponseWriter, request *ht
 			writer.Write([]byte(string(fmt.Sprint(err))))
 			return
 		}
-		key := partFileName(*s3Req.Key, *s3Req.PartNumber, handler.Config.GetString("gcp_destination_config.multipart_temp_file_prefix"))
+		key := partFileName(*s3Req.Key, *s3Req.PartNumber, handler.Config.GetString("gcp_destination_config.gcs_config.multipart_temp_file_prefix"))
 		bucket := handler.GCPClientToBucket(*s3Req.Bucket, client)
 		obj := handler.GCPBucketToObject(key, bucket)
 		uploader := handler.GCPObjectToWriter(obj, *handler.Context)

--- a/pkg/aws/handler/s3/object/object_handler_test.go
+++ b/pkg/aws/handler/s3/object/object_handler_test.go
@@ -256,8 +256,8 @@ func TestHandler_UploadPartHandle(t *testing.T) {
 func TestHandler_partFileName(t *testing.T) {
 	key := "bleh/meh/larry1.parquet"
 	noPrefix := partFileName(key, 0, "")
-	assert.Equal(t, noPrefix, key + "-part-0")
+	assert.Equal(t, noPrefix, key+"-part-0")
 
-	withPrefix := partFileName(key, 0, "_")
-	assert.Equal(t, withPrefix, "bleh/meh/_larry1.parquet-part-0")
+	withPrefix := partFileName(key, 0, "mytempplace")
+	assert.Equal(t, withPrefix, "mytempplace/bleh/meh/larry1.parquet-part-0")
 }

--- a/pkg/aws/handler/s3/object/object_handler_test.go
+++ b/pkg/aws/handler/s3/object/object_handler_test.go
@@ -198,7 +198,6 @@ func TestHandler_HeadParseInput(t *testing.T) {
 }
 
 func TestHandler_UploadPartHandle(t *testing.T) {
-
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	bucketMock := s3_handler.NewMockGCPBucket(ctrl)
@@ -252,4 +251,13 @@ func TestHandler_UploadPartHandle(t *testing.T) {
 	handler.UploadPartHandle(writerMock, req)
 	assert.Equal(t, header["Etag"][0], "3bde84208a4a41929d903d93120bb9c5")
 	assert.Empty(t, header["Content-Length"])
+}
+
+func TestHandler_partFileName(t *testing.T) {
+	key := "bleh/meh/larry1.parquet"
+	noPrefix := partFileName(key, 0, "")
+	assert.Equal(t, noPrefix, key + "-part-0")
+
+	withPrefix := partFileName(key, 0, "_")
+	assert.Equal(t, withPrefix, "bleh/meh/_larry1.parquet-part-0")
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,7 +53,7 @@ type GCPDestinationConfig struct {
 type GCSConfig struct {
 	BucketRename         map[string]string `mapstructure:"bucket_rename"`
 	MultipartDBDirectory string            `mapstructure:"multipart_db_directory"`
-	MultipartPrefix      string            `mapstructure:"multipart_temp_file_prefix"`
+	MultipartPathPrefix  string            `mapstructure:"multipart_temp_path_prefix"`
 }
 
 type GCPDatastoreConfig struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,6 +53,7 @@ type GCPDestinationConfig struct {
 type GCSConfig struct {
 	BucketRename         map[string]string `mapstructure:"bucket_rename"`
 	MultipartDBDirectory string            `mapstructure:"multipart_db_directory"`
+	MultipartPrefix      string            `mapstructure:"multipart_temp_file_prefix"`
 }
 
 type GCPDatastoreConfig struct {

--- a/pkg/server/listener.go
+++ b/pkg/server/listener.go
@@ -22,7 +22,7 @@ import (
 	"time"
 )
 
-const Version = "0.0.15"
+const Version = "0.0.16"
 
 // Handlers map
 var awsHandlers map[string]awshandler.HandlerInterface


### PR DESCRIPTION
This should prevent spark from picking up temporary upload files by prefixing them with _

Test Plan: wrote unit tests, going to run locally